### PR TITLE
Service Plan Concept

### DIFF
--- a/cmd/koli-controller/controller-manager.go
+++ b/cmd/koli-controller/controller-manager.go
@@ -3,19 +3,17 @@ package main
 import (
 	"flag"
 	"fmt"
-	"net/url"
-	"os"
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/kolibox/koli/pkg/controller"
-	"github.com/kolibox/koli/pkg/controller/informers"
 	"github.com/spf13/pflag"
 
+	"github.com/kolibox/koli/pkg/clientset"
+	"github.com/kolibox/koli/pkg/controller"
+	"github.com/kolibox/koli/pkg/controller/informers"
+	_ "github.com/kolibox/koli/pkg/spec/install"
+
 	"k8s.io/client-go/1.5/kubernetes"
-	"k8s.io/client-go/1.5/pkg/api"
-	"k8s.io/client-go/1.5/pkg/api/unversioned"
-	"k8s.io/client-go/1.5/pkg/runtime/serializer"
 	"k8s.io/client-go/1.5/pkg/util/wait"
 	"k8s.io/client-go/1.5/rest"
 )
@@ -39,24 +37,14 @@ func init() {
 	pflag.Parse()
 }
 
-func newSysRESTClient(c *rest.Config) (*rest.RESTClient, error) {
-	c.APIPath = "/apis"
-	c.GroupVersion = &unversioned.GroupVersion{
-		Group:   "sys.koli.io",
-		Version: "v1alpha1",
-	}
-	c.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: api.Codecs}
-	return rest.RESTClientFor(c)
-}
-
 func startControllers(stop <-chan struct{}) error {
-	cfg, err := newClusterConfig(cfg.Host, cfg.TLSInsecure, &cfg.TLSConfig)
+	cfg, err := clientset.NewClusterConfig(cfg.Host, cfg.TLSInsecure, &cfg.TLSConfig)
 	if err != nil {
 		return err
 	}
-	if os.Getenv("SUPER_USER_TOKEN") == "" {
-		return fmt.Errorf("SUPER_USER_TOKEN env not defined")
-	}
+	// if os.Getenv("SUPER_USER_TOKEN") == "" {
+	// 	return fmt.Errorf("SUPER_USER_TOKEN env not defined")
+	// }
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return err
@@ -67,57 +55,39 @@ func startControllers(stop <-chan struct{}) error {
 		return fmt.Errorf("communicating with server failed: %s", err)
 	}
 
-	// Provision third party resources
-	controller.CreateTPRs(cfg.Host, client)
+	// Create required third party resources
+	// controller.CreateAddonTPRs(cfg.Host, client)
+	// controller.CreateServicePlan3PRs(cfg.Host, client)
+	// controller.CreateServicePlanStatus3PRs(cfg.Host, client)
 
-	sysclient, err := newSysRESTClient(cfg)
+	sysClient, err := clientset.NewSysRESTClient(cfg)
 	if err != nil {
 		return err
 	}
 
 	sharedInformers := informers.NewSharedInformerFactory(client, 30*time.Second)
 
-	go controller.NewAddonController(
-		sharedInformers.Addons().Informer(sysclient),
-		sharedInformers.PetSets().Informer(),
-		client,
-	).Run(1, wait.NeverStop)
 	// TODO: should we use the same client instance??
-	go controller.NewNamespaceController(
-		sharedInformers.Namespaces().Informer(),
+	// go controller.NewAddonController(
+	// 	sharedInformers.Addons().Informer(sysClient),
+	// 	sharedInformers.PetSets().Informer(),
+	// 	client,
+	// ).Run(1, wait.NeverStop)
+
+	// go controller.NewNamespaceController(
+	// 	sharedInformers.Namespaces().Informer(),
+	// 	client,
+	// ).Run(1, wait.NeverStop)
+
+	go controller.NewServicePlanController(
+		sharedInformers.ServicePlans().Informer(sysClient),
 		client,
+		sysClient,
 	).Run(1, wait.NeverStop)
+
 	sharedInformers.Start(stop)
 
 	select {} // block forever
-}
-
-func newClusterConfig(host string, tlsInsecure bool, tlsConfig *rest.TLSClientConfig) (*rest.Config, error) {
-	var cfg *rest.Config
-	var err error
-
-	if len(host) == 0 {
-		if cfg, err = rest.InClusterConfig(); err != nil {
-			return nil, err
-		}
-	} else {
-		cfg = &rest.Config{
-			Host: host,
-		}
-		hostURL, err := url.Parse(host)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing host url %s : %v", host, err)
-		}
-		if hostURL.Scheme == "https" {
-			cfg.TLSClientConfig = *tlsConfig
-			cfg.Insecure = tlsInsecure
-		}
-	}
-	// cfg.BearerToken = os.Getenv("SUPER_USER_TOKEN")
-	cfg.QPS = 100
-	cfg.Burst = 100
-
-	return cfg, nil
 }
 
 func main() {

--- a/cmd/koli-controller/controller-manager.go
+++ b/cmd/koli-controller/controller-manager.go
@@ -56,9 +56,9 @@ func startControllers(stop <-chan struct{}) error {
 	}
 
 	// Create required third party resources
-	// controller.CreateAddonTPRs(cfg.Host, client)
-	// controller.CreateServicePlan3PRs(cfg.Host, client)
-	// controller.CreateServicePlanStatus3PRs(cfg.Host, client)
+	controller.CreateAddonTPRs(cfg.Host, client)
+	controller.CreateServicePlan3PRs(cfg.Host, client)
+	controller.CreateServicePlanStatus3PRs(cfg.Host, client)
 
 	sysClient, err := clientset.NewSysRESTClient(cfg)
 	if err != nil {
@@ -68,16 +68,16 @@ func startControllers(stop <-chan struct{}) error {
 	sharedInformers := informers.NewSharedInformerFactory(client, 30*time.Second)
 
 	// TODO: should we use the same client instance??
-	// go controller.NewAddonController(
-	// 	sharedInformers.Addons().Informer(sysClient),
-	// 	sharedInformers.PetSets().Informer(),
-	// 	client,
-	// ).Run(1, wait.NeverStop)
+	go controller.NewAddonController(
+		sharedInformers.Addons().Informer(sysClient),
+		sharedInformers.PetSets().Informer(),
+		client,
+	).Run(1, wait.NeverStop)
 
-	// go controller.NewNamespaceController(
-	// 	sharedInformers.Namespaces().Informer(),
-	// 	client,
-	// ).Run(1, wait.NeverStop)
+	go controller.NewNamespaceController(
+		sharedInformers.Namespaces().Informer(),
+		client,
+	).Run(1, wait.NeverStop)
 
 	go controller.NewServicePlanController(
 		sharedInformers.ServicePlans().Informer(sysClient),

--- a/pkg/clientset/addon.go
+++ b/pkg/clientset/addon.go
@@ -1,0 +1,166 @@
+package clientset
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/kolibox/koli/pkg/spec"
+	"k8s.io/client-go/1.5/pkg/api"
+	"k8s.io/client-go/1.5/pkg/api/unversioned"
+	"k8s.io/client-go/1.5/pkg/api/v1"
+	"k8s.io/client-go/1.5/pkg/runtime"
+	"k8s.io/client-go/1.5/pkg/watch"
+	"k8s.io/client-go/1.5/rest"
+)
+
+// AddonGetter has a method to return an AddonInterface.
+// A group's client should implement this interface.
+type AddonGetter interface {
+	Addon(namespace string) AddonInterface
+}
+
+// AddonInterface has methods to work with Addon resources.
+type AddonInterface interface {
+	List(opts *api.ListOptions) (*spec.AddonList, error)
+	Get(name string) (*spec.Addon, error)
+	Delete(name string, options *v1.DeleteOptions) error
+	Create(data *spec.Addon) (*spec.Addon, error)
+	Update(data *spec.Addon) (*spec.Addon, error)
+	Watch(opts *api.ListOptions) (watch.Interface, error)
+}
+
+// addon implements AddonInterface
+type addon struct {
+	client    *rest.RESTClient
+	namespace string
+	resource  *unversioned.APIResource
+}
+
+// Get gets the resource with the specified name.
+func (a *addon) Get(name string) (*spec.Addon, error) {
+	addon := &spec.Addon{}
+	err := a.client.Get().
+		NamespaceIfScoped(a.namespace, a.resource.Namespaced).
+		Resource(a.resource.Name).
+		Name(name).
+		Do().
+		Into(addon)
+	return addon, err
+}
+
+// List returns a list of objects for this resource.
+func (a *addon) List(opts *api.ListOptions) (*spec.AddonList, error) {
+	if opts == nil {
+		opts = &api.ListOptions{}
+	}
+	addonList := &spec.AddonList{}
+	err := a.client.Get().
+		NamespaceIfScoped(a.namespace, a.resource.Namespaced).
+		Resource(a.resource.Name).
+		FieldsSelectorParam(nil).
+		VersionedParams(opts, api.ParameterCodec). // TODO: test this option
+		Do().
+		Into(addonList)
+	return addonList, err
+}
+
+// Delete deletes the resource with the specified name.
+func (a *addon) Delete(name string, opts *v1.DeleteOptions) error {
+	if opts == nil {
+		opts = &v1.DeleteOptions{}
+	}
+	return a.client.Delete().
+		NamespaceIfScoped(a.namespace, a.resource.Namespaced).
+		Resource(a.resource.Name).
+		Name(name).
+		// TODO: https://github.com/kubernetes/kubernetes/issues/37278
+		// error: no kind "DeleteOptions" is registered for version "<3PR>"
+		// Body(opts).
+		Do().
+		Error()
+}
+
+// Create creates the provided resource.
+func (a *addon) Create(data *spec.Addon) (*spec.Addon, error) {
+	addon := &spec.Addon{}
+	err := a.client.Post().
+		NamespaceIfScoped(a.namespace, a.resource.Namespaced).
+		Resource(a.resource.Name).
+		Body(data).
+		Do().
+		Into(addon)
+	return addon, err
+}
+
+// Update updates the provided resource.
+func (a *addon) Update(data *spec.Addon) (*spec.Addon, error) {
+	addon := &spec.Addon{}
+	if len(data.GetName()) == 0 {
+		return data, errors.New("object missing name")
+	}
+	err := a.client.Put().
+		NamespaceIfScoped(a.namespace, a.resource.Namespaced).
+		Resource(a.resource.Name).
+		Name(data.GetName()).
+		Body(data).
+		Do().
+		Into(addon)
+	return addon, err
+}
+
+// Watch returns a watch.Interface that watches the resource.
+func (a *addon) Watch(opts *api.ListOptions) (watch.Interface, error) {
+	// TODO: Using Watch method gives the following error on creation and deletion of resources:
+	// expected type X, but watch event object had type *runtime.Unstructured
+	stream, err := a.client.Get().
+		Prefix("watch").
+		NamespaceIfScoped(a.namespace, a.resource.Namespaced).
+		Resource(a.resource.Name).
+		// VersionedParams(opts, spec.DefaultParameterEncoder).
+		VersionedParams(opts, api.ParameterCodec).
+		Stream()
+	if err != nil {
+		return nil, err
+	}
+
+	return watch.NewStreamWatcher(&addonDecoder{
+		dec:   json.NewDecoder(stream),
+		close: stream.Close,
+	}), nil
+}
+
+// Patch updates the provided resource
+func (a *addon) Patch(name string, pt api.PatchType, data []byte) (*spec.Addon, error) {
+	addon := &spec.Addon{}
+	err := a.client.Patch(pt).
+		NamespaceIfScoped(a.namespace, a.resource.Namespaced).
+		Resource(a.resource.Name).
+		Name(name).
+		Body(data).
+		Do().
+		Into(addon)
+	return addon, err
+}
+
+// addonDecoder provides a decoder for watching addon resources
+type addonDecoder struct {
+	dec   *json.Decoder
+	close func() error
+}
+
+// Close decoder
+func (d *addonDecoder) Close() {
+	d.close()
+}
+
+// Decode data
+func (d *addonDecoder) Decode() (watch.EventType, runtime.Object, error) {
+	var e struct {
+		Type   watch.EventType
+		Object spec.Addon
+	}
+	if err := d.dec.Decode(&e); err != nil {
+		return watch.Error, nil, err
+	}
+	return e.Type, &e.Object, nil
+}

--- a/pkg/clientset/clientset.go
+++ b/pkg/clientset/clientset.go
@@ -1,0 +1,80 @@
+package clientset
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/kolibox/koli/pkg/spec"
+
+	"k8s.io/client-go/1.5/dynamic"
+	"k8s.io/client-go/1.5/pkg/api/unversioned"
+	"k8s.io/client-go/1.5/rest"
+)
+
+// Interface core
+type Interface interface {
+	Core() CoreInterface
+}
+
+// Clientset contains the clients for groups. Each group has exactly one
+// version included in a Clientset.
+type Clientset struct {
+	*CoreClient
+}
+
+// Core retrieves the CoreClient
+func (c *Clientset) Core() CoreInterface {
+	if c == nil {
+		return nil
+	}
+	return c.CoreClient
+}
+
+// NewClusterConfig creates a new customized *rest.Config
+func NewClusterConfig(host string, tlsInsecure bool, tlsConfig *rest.TLSClientConfig) (*rest.Config, error) {
+	var cfg *rest.Config
+	var err error
+
+	if len(host) == 0 {
+		if cfg, err = rest.InClusterConfig(); err != nil {
+			return nil, err
+		}
+	} else {
+		cfg = &rest.Config{
+			Host: host,
+		}
+		hostURL, err := url.Parse(host)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing host url %s : %v", host, err)
+		}
+		if hostURL.Scheme == "https" {
+			cfg.TLSClientConfig = *tlsConfig
+			cfg.Insecure = tlsInsecure
+		}
+	}
+	cfg.QPS = 100
+	cfg.Burst = 100
+
+	return cfg, nil
+}
+
+// NewSysRESTClient generates a new *rest.RESTClient to communicate with system third party resources
+func NewSysRESTClient(c *rest.Config) (*CoreClient, error) {
+	c.APIPath = "/apis"
+
+	c.GroupVersion = &unversioned.GroupVersion{
+		Group:   spec.GroupName,
+		Version: spec.SchemeGroupVersion.Version,
+	}
+	contentConfig := dynamic.ContentConfig()
+	contentConfig.GroupVersion = &spec.SchemeGroupVersion
+	c.ContentConfig = contentConfig
+
+	// c.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: api.Codecs}
+
+	cl, err := rest.RESTClientFor(c)
+	if err != nil {
+		return nil, err
+	}
+	return &CoreClient{restClient: cl}, nil
+}

--- a/pkg/clientset/core.go
+++ b/pkg/clientset/core.go
@@ -1,0 +1,80 @@
+package clientset
+
+import (
+	"k8s.io/client-go/1.5/pkg/api/unversioned"
+	"k8s.io/client-go/1.5/rest"
+)
+
+// CoreInterface contains client third party resources
+type CoreInterface interface {
+	RESTClient() *rest.RESTClient
+
+	AddonGetter
+	ServicePlanGetter
+	ServicePlanStatusGetter
+}
+
+// CoreClient is used to interact with features provided by the Core group.
+type CoreClient struct {
+	restClient *rest.RESTClient
+}
+
+// RESTClient returns a RESTClient that is used to communicate
+// with API server by this client implementation.
+func (c *CoreClient) RESTClient() *rest.RESTClient {
+	if c == nil {
+		return nil
+	}
+	return c.restClient
+}
+
+// ServicePlanStatus generates a new client to communicate with ServicePlanStatus resources
+func (c *CoreClient) ServicePlanStatus(namespace string) ServicePlanStatusInterface {
+	return newServicePlanStatus(c, namespace)
+}
+
+// ServicePlan generates a new client to communicate with ServicePlan resources
+func (c *CoreClient) ServicePlan(namespace string) ServicePlanInterface {
+	return newServicePlan(c, namespace)
+}
+
+// Addon generates a new client to communnicate with Addon resources
+func (c *CoreClient) Addon(namespace string) AddonInterface {
+	return newAddon(c, namespace)
+}
+
+func newServicePlanStatus(c *CoreClient, namespace string) *servicePlanStatus {
+	return &servicePlanStatus{
+		client:    c.RESTClient(),
+		namespace: namespace,
+		resource: &unversioned.APIResource{
+			Name:       "serviceplanstatuses",
+			Namespaced: true,
+			Kind:       "Serviceplanstatus",
+		},
+	}
+}
+
+func newServicePlan(c *CoreClient, namespace string) *servicePlan {
+	return &servicePlan{
+		client:    c.RESTClient(),
+		namespace: namespace,
+		resource: &unversioned.APIResource{
+			Name:       "serviceplans",
+			Namespaced: true,
+			Kind:       "Serviceplan",
+		},
+	}
+}
+
+func newAddon(c *CoreClient, namespace string) *addon {
+	return &addon{
+		client:    c.RESTClient(),
+		namespace: namespace,
+		resource: &unversioned.APIResource{
+			Name:       "addons",
+			Namespaced: true,
+			Kind:       "Addon",
+		},
+	}
+}

--- a/pkg/clientset/serviceplan.go
+++ b/pkg/clientset/serviceplan.go
@@ -1,0 +1,163 @@
+package clientset
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/golang/glog"
+	"github.com/kolibox/koli/pkg/spec"
+	"k8s.io/client-go/1.5/pkg/api"
+	"k8s.io/client-go/1.5/pkg/api/unversioned"
+	"k8s.io/client-go/1.5/pkg/api/v1"
+	"k8s.io/client-go/1.5/pkg/runtime"
+	"k8s.io/client-go/1.5/pkg/watch"
+	"k8s.io/client-go/1.5/rest"
+)
+
+// ServicePlanGetter has a method to return an ServicePlanInterface.
+// A group's client should implement this interface.
+type ServicePlanGetter interface {
+	ServicePlan(namespace string) ServicePlanInterface
+}
+
+// ServicePlanInterface has methods to work with ServicePlan resources.
+type ServicePlanInterface interface {
+	List(opts *api.ListOptions) (*spec.ServicePlanList, error)
+	Get(name string) (*spec.ServicePlan, error)
+	Delete(name string, options *v1.DeleteOptions) error
+	Create(data *spec.ServicePlan) (*spec.ServicePlan, error)
+	Update(data *spec.ServicePlan) (*spec.ServicePlan, error)
+	Watch(opts *api.ListOptions) (watch.Interface, error)
+}
+
+// servicePlan implements ServicePlanInterface
+type servicePlan struct {
+	client    *rest.RESTClient
+	namespace string
+	resource  *unversioned.APIResource
+}
+
+// Get gets the resource with the specified name.
+func (s *servicePlan) Get(name string) (*spec.ServicePlan, error) {
+	sps := &spec.ServicePlan{}
+	err := s.client.Get().
+		NamespaceIfScoped(s.namespace, s.resource.Namespaced).
+		Resource(s.resource.Name).
+		Name(name).
+		Do().
+		Into(sps)
+	return sps, err
+}
+
+// List returns a list of objects for this resource.
+func (s *servicePlan) List(opts *api.ListOptions) (*spec.ServicePlanList, error) {
+	if opts == nil {
+		opts = &api.ListOptions{}
+	}
+	spList := &spec.ServicePlanList{}
+	err := s.client.Get().
+		NamespaceIfScoped(s.namespace, s.resource.Namespaced).
+		Resource(s.resource.Name).
+		// VersionedParams(opts).
+		Do().
+		Into(spList)
+	return spList, err
+}
+
+// Delete deletes the resource with the specified name.
+func (s *servicePlan) Delete(name string, opts *v1.DeleteOptions) error {
+	if opts == nil {
+		opts = &v1.DeleteOptions{}
+	}
+	return s.client.Delete().
+		NamespaceIfScoped(s.namespace, s.resource.Namespaced).
+		Resource(s.resource.Name).
+		Name(name).
+		// TODO: https://github.com/kubernetes/kubernetes/issues/37278
+		// error: no kind "DeleteOptions" is registered for version "<3PR>"
+		// Body(opts).
+		Do().
+		Error()
+}
+
+// Create creates the provided resource.
+func (s *servicePlan) Create(data *spec.ServicePlan) (*spec.ServicePlan, error) {
+	sps := &spec.ServicePlan{}
+	err := s.client.Post().
+		NamespaceIfScoped(s.namespace, s.resource.Namespaced).
+		Resource(s.resource.Name).
+		Body(data).
+		Do().
+		Into(sps)
+	return sps, err
+}
+
+// Update updates the provided resource.
+func (s *servicePlan) Update(data *spec.ServicePlan) (*spec.ServicePlan, error) {
+	sps := &spec.ServicePlan{}
+	if len(data.GetName()) == 0 {
+		return data, errors.New("object missing name")
+	}
+	err := s.client.Put().
+		NamespaceIfScoped(s.namespace, s.resource.Namespaced).
+		Resource(s.resource.Name).
+		Name(data.GetName()).
+		Body(data).
+		Do().
+		Into(sps)
+	return sps, err
+}
+
+// Watch returns a watch.Interface that watches the resource.
+func (s *servicePlan) Watch(opts *api.ListOptions) (watch.Interface, error) {
+	stream, err := s.client.Get().
+		Prefix("watch").
+		NamespaceIfScoped(s.namespace, s.resource.Namespaced).
+		Resource(s.resource.Name).
+		VersionedParams(opts, api.ParameterCodec).
+		Stream()
+	if err != nil {
+		return nil, err
+	}
+	return watch.NewStreamWatcher(&servicePlanDecoder{
+		dec:   json.NewDecoder(stream),
+		close: stream.Close,
+	}), nil
+}
+
+// Patch updates the provided resource
+func (s *servicePlan) Patch(name string, pt api.PatchType, data []byte) (*spec.ServicePlan, error) {
+	sps := &spec.ServicePlan{}
+	err := s.client.Patch(pt).
+		NamespaceIfScoped(s.namespace, s.resource.Namespaced).
+		Resource(s.resource.Name).
+		Name(name).
+		Body(data).
+		Do().
+		Into(sps)
+	return sps, err
+}
+
+// provides a decoder for watching 3PR resources
+type servicePlanDecoder struct {
+	dec   *json.Decoder
+	close func() error
+}
+
+// Close decoder
+func (d *servicePlanDecoder) Close() {
+	d.close()
+}
+
+// Decode data
+func (d *servicePlanDecoder) Decode() (watch.EventType, runtime.Object, error) {
+	var e struct {
+		Type   watch.EventType
+		Object spec.ServicePlan
+	}
+	if err := d.dec.Decode(&e); err != nil {
+		glog.Errorf("failed decoding service plan '%s': %s", e.Object.Name, err)
+		return watch.Error, nil, err
+	}
+	return e.Type, &e.Object, nil
+}

--- a/pkg/clientset/serviceplanstatus.go
+++ b/pkg/clientset/serviceplanstatus.go
@@ -1,0 +1,162 @@
+package clientset
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/kolibox/koli/pkg/spec"
+	"k8s.io/client-go/1.5/pkg/api"
+	"k8s.io/client-go/1.5/pkg/api/unversioned"
+	"k8s.io/client-go/1.5/pkg/api/v1"
+	"k8s.io/client-go/1.5/pkg/runtime"
+	"k8s.io/client-go/1.5/pkg/watch"
+	"k8s.io/client-go/1.5/rest"
+)
+
+// ServicePlanStatusGetter has a method to return an ServicePlanStatusInterface.
+// A group's client should implement this interface.
+type ServicePlanStatusGetter interface {
+	ServicePlanStatus(namespace string) ServicePlanStatusInterface
+}
+
+// ServicePlanStatusInterface has methods to work with ServicePlanStatus resources.
+type ServicePlanStatusInterface interface {
+	List(opts *api.ListOptions) (*spec.ServicePlanStatusList, error)
+	Get(name string) (*spec.ServicePlanStatus, error)
+	Delete(name string, options *v1.DeleteOptions) error
+	Create(data *spec.ServicePlanStatus) (*spec.ServicePlanStatus, error)
+	Update(data *spec.ServicePlanStatus) (*spec.ServicePlanStatus, error)
+	Watch(opts *api.ListOptions) (watch.Interface, error)
+}
+
+// servicePlanStatusks implements ServicePlanStatusInterface
+type servicePlanStatus struct {
+	client *rest.RESTClient
+	// client    restclient.Interface
+	namespace string
+	resource  *unversioned.APIResource
+}
+
+// Get gets the resource with the specified name.
+func (s *servicePlanStatus) Get(name string) (*spec.ServicePlanStatus, error) {
+	sps := &spec.ServicePlanStatus{}
+	err := s.client.Get().
+		NamespaceIfScoped(s.namespace, s.resource.Namespaced).
+		Resource(s.resource.Name).
+		Name(name).
+		Do().
+		Into(sps)
+	return sps, err
+}
+
+// List returns a list of objects for this resource.
+func (s *servicePlanStatus) List(opts *api.ListOptions) (*spec.ServicePlanStatusList, error) {
+	if opts == nil {
+		opts = &api.ListOptions{}
+	}
+	spsList := &spec.ServicePlanStatusList{}
+	err := s.client.Get().
+		NamespaceIfScoped(s.namespace, s.resource.Namespaced).
+		Resource(s.resource.Name).
+		// VersionedParams(opts, defaultParameterEncoder).
+		Do().
+		Into(spsList)
+	return spsList, err
+}
+
+// Delete deletes the resource with the specified name.
+func (s *servicePlanStatus) Delete(name string, opts *v1.DeleteOptions) error {
+	if opts == nil {
+		opts = &v1.DeleteOptions{}
+	}
+	return s.client.Delete().
+		NamespaceIfScoped(s.namespace, s.resource.Namespaced).
+		Resource(s.resource.Name).
+		Name(name).
+		// TODO: https://github.com/kubernetes/kubernetes/issues/37278
+		// error: no kind "DeleteOptions" is registered for version "<3PR>"
+		// Body(opts).
+		Do().
+		Error()
+}
+
+// Create creates the provided resource.
+func (s *servicePlanStatus) Create(data *spec.ServicePlanStatus) (*spec.ServicePlanStatus, error) {
+	sps := &spec.ServicePlanStatus{}
+	err := s.client.Post().
+		NamespaceIfScoped(s.namespace, s.resource.Namespaced).
+		Resource(s.resource.Name).
+		Body(data).
+		Do().
+		Into(sps)
+	return sps, err
+}
+
+// Update updates the provided resource.
+func (s *servicePlanStatus) Update(data *spec.ServicePlanStatus) (*spec.ServicePlanStatus, error) {
+	sps := &spec.ServicePlanStatus{}
+	if len(data.GetName()) == 0 {
+		return data, errors.New("object missing name")
+	}
+	err := s.client.Put().
+		NamespaceIfScoped(s.namespace, s.resource.Namespaced).
+		Resource(s.resource.Name).
+		Name(data.GetName()).
+		Body(data).
+		Do().
+		Into(sps)
+	return sps, err
+}
+
+// Watch returns a watch.Interface that watches the resource.
+func (s *servicePlanStatus) Watch(opts *api.ListOptions) (watch.Interface, error) {
+	stream, err := s.client.Get().
+		Prefix("watch").
+		NamespaceIfScoped(s.namespace, s.resource.Namespaced).
+		Resource(s.resource.Name).
+		VersionedParams(opts, api.ParameterCodec).
+		Stream()
+	if err != nil {
+		return nil, err
+	}
+	return watch.NewStreamWatcher(&servicePlanStatusDecoder{
+		dec:   json.NewDecoder(stream),
+		close: stream.Close,
+	}), nil
+}
+
+// Patch updates the provided resource
+func (s *servicePlanStatus) Patch(name string, pt api.PatchType, data []byte) (*spec.ServicePlanStatus, error) {
+	sps := &spec.ServicePlanStatus{}
+	err := s.client.Patch(pt).
+		NamespaceIfScoped(s.namespace, s.resource.Namespaced).
+		Resource(s.resource.Name).
+		Name(name).
+		Body(data).
+		Do().
+		Into(sps)
+	return sps, err
+}
+
+// provides a decoder for watching 3PR resources
+type servicePlanStatusDecoder struct {
+	dec   *json.Decoder
+	close func() error
+}
+
+// Close decoder
+func (d *servicePlanStatusDecoder) Close() {
+	d.close()
+}
+
+// Decode data
+func (d *servicePlanStatusDecoder) Decode() (watch.EventType, runtime.Object, error) {
+	var e struct {
+		Type   watch.EventType
+		Object spec.ServicePlanStatus
+	}
+	if err := d.dec.Decode(&e); err != nil {
+		return watch.Error, nil, err
+	}
+	return e.Type, &e.Object, nil
+}

--- a/pkg/controller/informers/informer.go
+++ b/pkg/controller/informers/informer.go
@@ -16,6 +16,7 @@ type SharedInformerFactory interface {
 	Start(stopCh <-chan struct{})
 
 	Addons() AddonInformer
+	ServicePlans() ServicePlanInformer
 	PetSets() PetSetInformer
 	Namespaces() NamespaceInformer
 }
@@ -57,6 +58,11 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 // Addons returns a SharedIndexInformer that lists and watches all addons
 func (f *sharedInformerFactory) Addons() AddonInformer {
 	return &addonInformer{sharedInformerFactory: f}
+}
+
+// ServicePlans returns a SharedIndexInformer that lists and watches all service plans
+func (f *sharedInformerFactory) ServicePlans() ServicePlanInformer {
+	return &servicePlanInformer{sharedInformerFactory: f}
 }
 
 // PetSets returns a SharedIndexInformer that lists and watchs all petsets

--- a/pkg/controller/namespace.go
+++ b/pkg/controller/namespace.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/client-go/1.5/tools/cache"
 )
 
-// NamespaceController .
+// NamespaceController controller
 type NamespaceController struct {
 	kclient *kubernetes.Clientset
 	nsInf   cache.SharedIndexInformer
@@ -158,8 +158,7 @@ func (c *NamespaceController) reconcile(ns *v1.Namespace) error {
 	// TODO: create a network policy allowing traffic between pods in the same namespace
 	// TODO: hard-coded quota for namespaces
 
-	label := spec.NewLabel()
-	label.Add(map[string]string{
+	label := spec.NewLabel().Add(map[string]string{
 		"default":  "true",
 		"customer": u.Customer,
 		"org":      u.Organization,

--- a/pkg/controller/serviceplan.go
+++ b/pkg/controller/serviceplan.go
@@ -1,0 +1,252 @@
+package controller
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/kolibox/koli/pkg/clientset"
+	"github.com/kolibox/koli/pkg/spec"
+
+	"k8s.io/client-go/1.5/kubernetes"
+	apierrors "k8s.io/client-go/1.5/pkg/api/errors"
+	"k8s.io/client-go/1.5/pkg/api/unversioned"
+	"k8s.io/client-go/1.5/pkg/api/v1"
+	extensions "k8s.io/client-go/1.5/pkg/apis/extensions/v1beta1"
+	utilruntime "k8s.io/client-go/1.5/pkg/util/runtime"
+	"k8s.io/client-go/1.5/pkg/util/wait"
+	"k8s.io/client-go/1.5/tools/cache"
+)
+
+const (
+	tprServicePlan       = "serviceplan.sys.koli.io"
+	tprServicePlanStatus = "serviceplanstatus.sys.koli.io"
+	systemNamespace      = "koli-system"
+)
+
+// ServicePlanController controller
+type ServicePlanController struct {
+	kclient   *kubernetes.Clientset
+	sysClient clientset.CoreInterface
+
+	spInf cache.SharedIndexInformer
+
+	queue *queue
+}
+
+// NewServicePlanController create a new ServicePlanController
+func NewServicePlanController(spInf cache.SharedIndexInformer, client *kubernetes.Clientset, sysClient clientset.CoreInterface) *ServicePlanController {
+	spc := &ServicePlanController{
+		kclient:   client,
+		sysClient: sysClient,
+		spInf:     spInf,
+		queue:     newQueue(200),
+	}
+
+	spc.spInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    spc.addServicePlan,
+		UpdateFunc: spc.updateServicePlan,
+		DeleteFunc: spc.deleteServicePlan,
+	})
+
+	return spc
+}
+
+// Run the controller.
+func (c *ServicePlanController) Run(workers int, stopc <-chan struct{}) {
+	// don't let panics crash the process
+	defer utilruntime.HandleCrash()
+	// make sure the work queue is shutdown which will trigger workers to end
+	defer c.queue.close()
+
+	glog.Info("Starting ServicePlan controller...")
+
+	for i := 0; i < workers; i++ {
+		// runWorker will loop until "something bad" happens.
+		// The .Until will then rekick the worker after one second
+		go wait.Until(c.runWorker, time.Second, stopc)
+	}
+
+	if !cache.WaitForCacheSync(stopc, c.spInf.HasSynced) {
+		return
+	}
+
+	// wait until we're told to stop
+	<-stopc
+	glog.Info("shutting down addon controller")
+}
+
+// runWorker runs a worker thread that just dequeues items, processes them, and marks them done.
+// It enforces that the syncHandler is never invoked concurrently with the same key.
+func (c *ServicePlanController) runWorker() {
+	for {
+		sp, ok := c.queue.pop(&spec.ServicePlan{})
+		if !ok {
+			return
+		}
+		if err := c.reconcile(sp.(*spec.ServicePlan)); err != nil {
+			utilruntime.HandleError(err)
+		}
+	}
+}
+
+func (c *ServicePlanController) reconcile(sp *spec.ServicePlan) error {
+	key, err := keyFunc(sp)
+	if err != nil {
+		return err
+	}
+
+	glog.Infof("RECONCILE: %s", key)
+	_, exists, err := c.spInf.GetStore().GetByKey(key)
+	if err != nil {
+		return err
+	}
+
+	if sp.Namespace == systemNamespace {
+		glog.Info("cluster plan, ignoring ...")
+		// TODO: rules for cluster service plans
+		return nil
+	}
+
+	if !exists {
+		glog.Infof("removing status for '%s'", key)
+		// TODO: We should not rely on this behavior because is not reliable
+		// the proper way to deal with this is garbage collecting orphan resources
+		if err := c.sysClient.ServicePlanStatus(sp.Namespace).Delete(sp.Name, nil); err != nil {
+			glog.Warningf("failed removing service plan status '%s': %s", key, err)
+		}
+		return nil
+	}
+
+	exists = true
+	if _, err := c.sysClient.ServicePlanStatus(sp.Namespace).Get(sp.Name); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed retrieving status for '%s': %s)", key, err)
+		}
+		exists = false
+	}
+
+	status := &spec.ServicePlanStatus{
+		TypeMeta: unversioned.TypeMeta{
+			Kind:       "Serviceplanstatus",
+			APIVersion: spec.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: sp.Name,
+		},
+		Phase: spec.ServicePlanActive,
+	}
+
+	// the reference plan
+	clusterPlan := sp.ObjectMeta.Labels["koli.io/clusterplan"]
+	if c.planExists(clusterPlan) {
+		label := spec.NewLabel().Add(map[string]string{
+			"clusterplan": clusterPlan,
+		})
+		status.Labels = label.Set
+	} else {
+		// the cluster plan is referenced by a label,
+		// change the status of the plan if isn't set
+		status.Phase = spec.ServicePlanNotFound
+	}
+
+	if !exists {
+		if _, err := c.sysClient.ServicePlanStatus(sp.Namespace).Create(status); err != nil {
+			glog.Warningf("failed generating status for '%s': %s", key, err)
+		}
+		return nil
+	}
+
+	if _, err := c.sysClient.ServicePlanStatus(sp.Namespace).Update(status); err != nil {
+		glog.Warningf("failed update status for '%s': %s", key, err)
+	}
+	return nil
+}
+
+func (c *ServicePlanController) addServicePlan(sp interface{}) {
+	splan := sp.(*spec.ServicePlan)
+	glog.Infof("ADD: %s/%s", splan.Namespace, splan.Name)
+	c.queue.add(sp.(*spec.ServicePlan))
+}
+
+func (c *ServicePlanController) updateServicePlan(o, n interface{}) {
+	old := o.(*spec.ServicePlan)
+	new := n.(*spec.ServicePlan)
+
+	if old.ResourceVersion == new.ResourceVersion {
+		glog.Infof("UPDATE: resource version match for '%s/%s'", new.Namespace, new.Name)
+	} else {
+		glog.Infof("UPDATE: new version for %s/%s", new.Namespace, new.Name)
+	}
+
+	c.queue.add(new)
+}
+
+func (c *ServicePlanController) deleteServicePlan(sp interface{}) {
+	splan := sp.(*spec.ServicePlan)
+	glog.Infof("DELETE: %s/%s", splan.Namespace, splan.Name)
+	c.queue.add(splan)
+}
+
+// Verify if the reference plan exists
+func (c *ServicePlanController) planExists(planName string) bool {
+	if planName == "" {
+		return false
+	}
+	if _, err := c.sysClient.ServicePlan(systemNamespace).Get(planName); err != nil {
+		glog.Warningf("failed listing cluster plan '%s': %s", planName, err)
+		return false
+	}
+	return true
+}
+
+// CreateServicePlan3PRs generates the third party resource required for interacting with Service Plans
+func CreateServicePlan3PRs(host string, kclient *kubernetes.Clientset) error {
+	tprs := []*extensions.ThirdPartyResource{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name: tprServicePlan,
+			},
+			Versions: []extensions.APIVersion{
+				{Name: "v1alpha1"},
+			},
+			Description: "Service Plan resource aggregation",
+		},
+	}
+	tprClient := kclient.Extensions().ThirdPartyResources()
+	for _, tpr := range tprs {
+		if _, err := tprClient.Create(tpr); err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		glog.Infof("third party resource '%s' provisioned", tpr.Name)
+	}
+
+	// We have to wait for the TPRs to be ready. Otherwise the initial watch may fail.
+	return watch3PRs(host, "/apis/sys.koli.io/v1alpha1/serviceplans", kclient)
+}
+
+// CreateServicePlanStatus3PRs generates the third party resource required for informing
+// the status of a Service Plan
+func CreateServicePlanStatus3PRs(host string, kclient *kubernetes.Clientset) error {
+	tprs := []*extensions.ThirdPartyResource{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name: tprServicePlanStatus,
+			},
+			Versions: []extensions.APIVersion{
+				{Name: "v1alpha1"},
+			},
+			Description: "Service Plan Status",
+		},
+	}
+	tprClient := kclient.Extensions().ThirdPartyResources()
+	for _, tpr := range tprs {
+		if _, err := tprClient.Create(tpr); err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		glog.Infof("third party resource '%s' provisioned", tpr.Name)
+	}
+
+	// We have to wait for the TPRs to be ready. Otherwise the initial watch may fail.
+	return watch3PRs(host, "/apis/sys.koli.io/v1alpha1/serviceplanstatus", kclient)
+}

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -1,0 +1,32 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"k8s.io/client-go/1.5/kubernetes"
+	"k8s.io/client-go/1.5/pkg/util/wait"
+	"k8s.io/client-go/1.5/tools/cache"
+)
+
+var keyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
+
+func watch3PRs(host, endpoint string, kclient *kubernetes.Clientset) error {
+	return wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
+		resp, err := kclient.CoreClient.Client.Get(host + endpoint)
+		if err != nil {
+			return false, err
+		}
+		defer resp.Body.Close()
+
+		switch resp.StatusCode {
+		case http.StatusOK:
+			return true, nil
+		case http.StatusNotFound: // not set up yet. wait.
+			return false, nil
+		default:
+			return false, fmt.Errorf("invalid status code: %v", resp.Status)
+		}
+	})
+}

--- a/pkg/spec/install/install.go
+++ b/pkg/spec/install/install.go
@@ -1,0 +1,22 @@
+package install
+
+import (
+	"github.com/kolibox/koli/pkg/spec"
+	"k8s.io/client-go/1.5/pkg/apimachinery/announced"
+)
+
+func init() {
+	if err := announced.NewGroupMetaFactory(
+		&announced.GroupMetaFactoryArgs{
+			GroupName:                  spec.GroupName,
+			VersionPreferenceOrder:     []string{spec.SchemeGroupVersion.Version},
+			ImportPrefix:               "github.com/kolibox/koli/pkg/spec",
+			AddInternalObjectsToScheme: spec.AddToScheme,
+		},
+		announced.VersionToSchemeFunc{
+			spec.SchemeGroupVersion.Version: spec.AddToScheme,
+		},
+	).Announce().RegisterAndEnable(); err != nil {
+		panic(err)
+	}
+}

--- a/pkg/spec/register.go
+++ b/pkg/spec/register.go
@@ -1,0 +1,44 @@
+package spec
+
+import (
+	"k8s.io/client-go/1.5/pkg/api"
+	"k8s.io/client-go/1.5/pkg/api/unversioned"
+	"k8s.io/client-go/1.5/pkg/runtime"
+)
+
+// GroupName is the group name use in this package
+const GroupName = "sys.koli.io"
+
+// SchemeGroupVersion is group version used to register these objects
+// var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
+var SchemeGroupVersion = unversioned.GroupVersion{Group: GroupName, Version: "v1alpha1"}
+
+// Kind takes an unqualified kind and returns a Group qualified GroupKind
+func Kind(kind string) unversioned.GroupKind {
+	return SchemeGroupVersion.WithKind(kind).GroupKind()
+}
+
+// Resource takes an unqualified resource and returns a Group qualified GroupResource
+func Resource(resource string) unversioned.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
+
+var (
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme   = SchemeBuilder.AddToScheme
+)
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	// TODO this gets cleaned up when the types are fixed
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&Addon{},
+		&AddonList{},
+		&ServicePlan{},
+		&ServicePlanList{},
+		&ServicePlanStatus{},
+		&ServicePlanStatusList{},
+		&api.ListOptions{},
+	)
+	return nil
+}

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -1,0 +1,108 @@
+package spec
+
+import (
+	"k8s.io/client-go/1.5/pkg/api/unversioned"
+	"k8s.io/client-go/1.5/pkg/api/v1"
+)
+
+// ServicePlan defines how resources could be managed and distributed
+type ServicePlan struct {
+	unversioned.TypeMeta `json:",inline"`
+	v1.ObjectMeta        `json:"metadata,omitempty"`
+
+	Spec ServicePlanSpec `json:"spec"`
+}
+
+// ServicePlanList is a list of ServicePlans
+type ServicePlanList struct {
+	unversioned.TypeMeta `json:",inline"`
+	unversioned.ListMeta `json:"metadata,omitempty"`
+
+	Items []*ServicePlan `json:"items"`
+}
+
+// ServicePlanSpec holds specification parameters of an ServicePlan
+type ServicePlanSpec struct {
+	// Compute Resources required by containers.
+	Resources v1.ResourceRequirements `json:"resources,omitempty"`
+	// Hard is the set of desired hard limits for each named resource.
+	Hard     v1.ResourceList     `json:"hard,omitempty"`
+	Features ServicePlanFeatures `json:"features,omitempty"`
+}
+
+// ServicePlanFeatures defines the permissions for a ServicePlan
+type ServicePlanFeatures struct {
+	PodManagement struct {
+		Exec        bool `json:"exec"`
+		PortForward bool `json:"portForward"`
+		AutoScale   bool `json:"autoScale"`
+		Attach      bool `json:"attach"`
+	} `json:"podManagement"`
+	AddonManagement bool `json:"addonManagement"`
+	MetricsAccess   bool `json:"metricsAccess"`
+}
+
+// ServicePlanStatus is information about the current status of a ServicePlan.
+type ServicePlanStatus struct {
+	unversioned.TypeMeta `json:",inline"`
+	v1.ObjectMeta        `json:"metadata,omitempty"`
+
+	// Phase is the current lifecycle phase of the namespace.
+	Phase ServicePlanPhase `json:"phase"`
+}
+
+// ServicePlanStatusList is a list of ServicePlanStatus
+type ServicePlanStatusList struct {
+	unversioned.TypeMeta `json:",inline"`
+	unversioned.ListMeta `json:"metadata,omitempty"`
+
+	Items []*ServicePlanStatus `json:"items"`
+}
+
+type ServicePlanPhase string
+
+const (
+	// ServicePlanActive means the ServicePlan is available for use in the system
+	ServicePlanActive ServicePlanPhase = "Active"
+	// ServicePlanPending means the ServicePlan isn't associate with any global ServicePlan
+	ServicePlanPending ServicePlanPhase = "Pending"
+	// ServicePlanNotFound means the reference plan wasn't found
+	ServicePlanNotFound ServicePlanPhase = "NotFound"
+	// ServicePlanDisabled means the ServicePlan is disabled and cannot be associated with resources
+	ServicePlanDisabled ServicePlanPhase = "Disabled"
+)
+
+// Addon defines integration with external resources
+type Addon struct {
+	unversioned.TypeMeta `json:",inline"`
+	v1.ObjectMeta        `json:"metadata,omitempty"`
+	Spec                 AddonSpec `json:"spec"`
+}
+
+// AddonList is a list of Addons.
+type AddonList struct {
+	unversioned.TypeMeta `json:",inline"`
+	unversioned.ListMeta `json:"metadata,omitempty"`
+
+	Items []*Addon `json:"items"`
+}
+
+// AddonSpec holds specification parameters of an addon
+type AddonSpec struct {
+	Type      string      `json:"type"`
+	BaseImage string      `json:"baseImage"`
+	Version   string      `json:"version"`
+	Replicas  int32       `json:"replicas"`
+	Port      int32       `json:"port"`
+	Env       []v1.EnvVar `json:"env"`
+	// More info: http://releases.k8s.io/HEAD/docs/user-guide/containers.md#containers-and-commands
+	Args []string `json:"args,omitempty"`
+}
+
+// User identifies an user on the platform
+type User struct {
+	ID           string `json:"id"`
+	Username     string `json:"username"`
+	Organization string `json:"org"`
+	Customer     string `json:"customer"`
+}


### PR DESCRIPTION
Closes #54 

```yaml
# koli-hobby.yml cluster plan
# kubectl create -f koli-hobby.yml -n koli-system
apiVersion: sys.koli.io/v1alpha1
kind: Serviceplan
metadata:
  name: hobby
  labels:
    'koli.io/default': 'true'
spec:
  resources:
    requests:
      cpu: 140
      memory: 128
```

```yaml
# koli-pro.yml cluster plan
# kubectl create -f koli-pro.yml -n koli-system
apiVersion: sys.koli.io/v1alpha1
kind: Serviceplan
metadata:
  name: professional
spec:
  resources:
    requests:
      cpu: 240
      memory: 256
```

```yaml
# broker-pro.yml broker plan
# kubectl create -f broker-pro.yml
apiVersion: sys.koli.io/v1alpha1
kind: Serviceplan
metadata:
  name: standard
  labels:
    'koli.io/clusterplan': 'professional'
spec:
  hard:
    pods: 10
    services: 15
    configmaps: 25
  features:
    podManagement:
      exec: false
      portForward: true
    addonManagement: true
    metricsAccess: false
```